### PR TITLE
新着投稿タブ追加 Feature/125++

### DIFF
--- a/src/app/event/event/event.component.html
+++ b/src/app/event/event/event.component.html
@@ -19,7 +19,7 @@
             <ul class="users">
               <li
                 class="users__item"
-                [style.background-image]="'url(' + event.user.avatarURL + ')'"
+                [style.background-image]="'url(' + event.user?.avatarURL + ')'"
               ></li>
             </ul>
           </dd>

--- a/src/app/event/event/image-list/image-card/image-card.component.html
+++ b/src/app/event/event/image-list/image-card/image-card.component.html
@@ -27,14 +27,14 @@
   <div class="image-card__body">
     <ng-container *ngIf="!isLiked">
       <button mat-icon-button (click)="likeImage(image.imageId)">
-        <mat-icon>favorite_border</mat-icon>
-        <span>{{ likedCount }}</span>
+        <mat-icon class="image-card__like">favorite_border</mat-icon>
+        <span class="image-card__like-count">{{ likedCount }}</span>
       </button>
     </ng-container>
     <ng-container *ngIf="isLiked">
       <button mat-icon-button (click)="UnLikeImage(image.imageId)">
-        <mat-icon>favorite</mat-icon>
-        <span>{{ likedCount }}</span>
+        <mat-icon class="image-card__like">favorite</mat-icon>
+        <span class="image-card__like-count">{{ likedCount }}</span>
       </button>
     </ng-container>
     <a

--- a/src/app/event/event/image-list/image-card/image-card.component.scss
+++ b/src/app/event/event/image-list/image-card/image-card.component.scss
@@ -42,8 +42,21 @@
     align-items: center;
     justify-content: flex-end;
   }
+  &__like {
+    font-size: 16px;
+    @include pc {
+      font-size: 18px;
+    }
+  }
+  &__like-count {
+    font-size: 14px;
+  }
   &__comment {
     display: block;
-    padding: 16px;
+    padding: 8px;
+    font-size: 10px;
+    @include pc {
+      font-size: 14px;
+    }
   }
 }

--- a/src/app/home/home.module.ts
+++ b/src/app/home/home.module.ts
@@ -14,6 +14,7 @@ import { JoinEventDialogComponent } from './home/join-event-dialog/join-event-di
 import { SharedModule } from '../shared/shared.module';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { RecentPostsComponent } from './recent-posts/recent-posts.component';
 
 @NgModule({
   declarations: [
@@ -21,6 +22,7 @@ import { MatSnackBarModule } from '@angular/material/snack-bar';
     CreateEventDialogComponent,
     JoinEventDialogComponent,
     EventListCardComponent,
+    RecentPostsComponent,
   ],
   imports: [
     CommonModule,

--- a/src/app/home/home/home.component.html
+++ b/src/app/home/home/home.component.html
@@ -18,6 +18,16 @@
   </div>
 
   <mat-tab-group class="mat-tab" mat-align-tabs="center">
+    <mat-tab label="新着投稿">
+      <div class="mat-tab__card-layout mat-tab__card-layout--posts">
+        <app-recent-posts
+          *ngFor="let image of images$ | async as images"
+          [image]="image"
+          [routerLink]="'/event/' + image.eventId"
+        ></app-recent-posts>
+      </div>
+    </mat-tab>
+
     <mat-tab label="主催イベント">
       <div class="mat-tab__card-layout">
         <app-event-list-card

--- a/src/app/home/home/home.component.scss
+++ b/src/app/home/home/home.component.scss
@@ -54,7 +54,7 @@
 }
 
 .mat-tab {
-  height: 100vh;
+  height: 100%;
   &__card-layout {
     display: grid;
     grid-template-columns: 1fr;
@@ -65,6 +65,9 @@
       grid-template-columns: repeat(3, 1fr);
       place-items: center;
       padding: 24px 48px;
+    }
+    &--posts {
+      padding: 24px 0;
     }
   }
 }

--- a/src/app/home/home/home.component.ts
+++ b/src/app/home/home/home.component.ts
@@ -4,9 +4,11 @@ import { ActivatedRoute } from '@angular/router';
 import { Observable } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
 import { Event } from 'src/app/interfaces/event';
+import { Image } from 'src/app/interfaces/image';
 import { User } from 'src/app/interfaces/user';
 import { AuthService } from 'src/app/services/auth.service';
 import { EventService } from 'src/app/services/event.service';
+import { ImageService } from 'src/app/services/image.service';
 import { CreateEventDialogComponent } from './create-event-dialog/create-event-dialog.component';
 import { JoinEventDialogComponent } from './join-event-dialog/join-event-dialog.component';
 
@@ -16,7 +18,9 @@ import { JoinEventDialogComponent } from './join-event-dialog/join-event-dialog.
   styleUrls: ['./home.component.scss'],
 })
 export class HomeComponent implements OnInit {
+  uid: string;
   user$: Observable<User> = this.authService.user$;
+  images$: Observable<Image[]>;
 
   eventId$: Observable<string> = this.route.paramMap.pipe(
     map((param) => {
@@ -42,7 +46,8 @@ export class HomeComponent implements OnInit {
     private dialog: MatDialog,
     private route: ActivatedRoute,
     private eventService: EventService,
-    private authService: AuthService
+    private authService: AuthService,
+    private imageService: ImageService
   ) {}
 
   ngOnInit(): void {
@@ -51,6 +56,10 @@ export class HomeComponent implements OnInit {
         this.openJoinEventDialog(id);
       }
     });
+    this.user$.subscribe((user) => {
+      this.uid = user.uid;
+    });
+    this.images$ = this.imageService.getRecentImagesInJoinedEvents(this.uid);
   }
 
   openJoinEventDialog(id?: string) {

--- a/src/app/home/recent-posts/recent-posts.component.html
+++ b/src/app/home/recent-posts/recent-posts.component.html
@@ -1,0 +1,8 @@
+<div class="tile" ontouchstart>
+  <img [src]="image.imageURL" />
+  <div class="tile__body">
+    <div class="tile__date">
+      {{ image.createAt.toDate() | date: 'yyyy/MM/dd HH:mm' }}
+    </div>
+  </div>
+</div>

--- a/src/app/home/recent-posts/recent-posts.component.html
+++ b/src/app/home/recent-posts/recent-posts.component.html
@@ -1,6 +1,9 @@
 <div class="tile" ontouchstart>
   <img [src]="image.imageURL" />
   <div class="tile__body">
+    <div class="tile__name">
+      <!-- <p>{{ image.user.name }}</p> -->
+    </div>
     <div class="tile__date">
       {{ image.createAt.toDate() | date: 'yyyy/MM/dd HH:mm' }}
     </div>

--- a/src/app/home/recent-posts/recent-posts.component.html
+++ b/src/app/home/recent-posts/recent-posts.component.html
@@ -1,9 +1,15 @@
 <div class="tile" ontouchstart>
+  <div class="tile__head">
+    <ng-container *ngIf="image.user?.avatarURL; else default">
+      <img class="tile__avatar" [src]="image.user?.avatarURL" alt="" />
+    </ng-container>
+    <ng-template #default>
+      <mat-icon class="tile__avatar">account_circle</mat-icon>
+    </ng-template>
+    <p class="tile__name">{{ image.user?.name }}</p>
+  </div>
   <img [src]="image.imageURL" />
   <div class="tile__body">
-    <div class="tile__name">
-      <!-- <p>{{ image.user.name }}</p> -->
-    </div>
     <div class="tile__date">
       {{ image.createAt.toDate() | date: 'yyyy/MM/dd HH:mm' }}
     </div>

--- a/src/app/home/recent-posts/recent-posts.component.scss
+++ b/src/app/home/recent-posts/recent-posts.component.scss
@@ -6,9 +6,36 @@
   border-radius: 10px;
   cursor: pointer;
   box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 16px;
+  &__head {
+    display: flex;
+    align-items: center;
+    vertical-align: middle;
+    padding: 8px;
+  }
+  &__avatar {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    font-size: 40px;
+    color: rgba(#212121, 0.6);
+  }
+  &__name {
+    font-size: 12px;
+    margin: 0 8px;
+    @include pc {
+      font-size: 14px;
+    }
+  }
   &__body {
     padding: 8px;
     font-size: 10px;
+    @include pc {
+      font-size: 14px;
+    }
+  }
+  &__date {
+    font-size: 10px;
+    opacity: 0.6;
     @include pc {
       font-size: 14px;
     }

--- a/src/app/home/recent-posts/recent-posts.component.scss
+++ b/src/app/home/recent-posts/recent-posts.component.scss
@@ -1,0 +1,16 @@
+@import 'mixins';
+@import 'variables';
+
+.tile {
+  max-width: 304px;
+  border-radius: 10px;
+  cursor: pointer;
+  box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 16px;
+  &__body {
+    padding: 8px;
+    font-size: 10px;
+    @include pc {
+      font-size: 14px;
+    }
+  }
+}

--- a/src/app/home/recent-posts/recent-posts.component.spec.ts
+++ b/src/app/home/recent-posts/recent-posts.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RecentPostsComponent } from './recent-posts.component';
+
+describe('RecentPostsComponent', () => {
+  let component: RecentPostsComponent;
+  let fixture: ComponentFixture<RecentPostsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [RecentPostsComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RecentPostsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/home/recent-posts/recent-posts.component.ts
+++ b/src/app/home/recent-posts/recent-posts.component.ts
@@ -1,8 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { Observable } from 'rxjs';
-import { Image } from 'src/app/interfaces/image';
-import { User } from 'src/app/interfaces/user';
-import { AuthService } from 'src/app/services/auth.service';
+import { Image, ImageWithUser } from 'src/app/interfaces/image';
 
 @Component({
   selector: 'app-recent-posts',
@@ -10,7 +7,7 @@ import { AuthService } from 'src/app/services/auth.service';
   styleUrls: ['./recent-posts.component.scss'],
 })
 export class RecentPostsComponent implements OnInit {
-  @Input() image: Image;
+  @Input() image: ImageWithUser;
 
   constructor() {}
 

--- a/src/app/home/recent-posts/recent-posts.component.ts
+++ b/src/app/home/recent-posts/recent-posts.component.ts
@@ -1,0 +1,18 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { Observable } from 'rxjs';
+import { Image } from 'src/app/interfaces/image';
+import { User } from 'src/app/interfaces/user';
+import { AuthService } from 'src/app/services/auth.service';
+
+@Component({
+  selector: 'app-recent-posts',
+  templateUrl: './recent-posts.component.html',
+  styleUrls: ['./recent-posts.component.scss'],
+})
+export class RecentPostsComponent implements OnInit {
+  @Input() image: Image;
+
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/interfaces/image.ts
+++ b/src/app/interfaces/image.ts
@@ -1,4 +1,5 @@
 import { Data } from '@angular/router';
+import { User } from './user';
 
 export interface Image {
   imageId?: string;
@@ -9,4 +10,8 @@ export interface Image {
   likedUid?: string;
   likedCount?: string;
   comment?: string;
+}
+
+export interface ImageWithUser extends Image {
+  user: User;
 }

--- a/src/app/services/image.service.ts
+++ b/src/app/services/image.service.ts
@@ -2,15 +2,8 @@ import { Injectable } from '@angular/core';
 import { AngularFirestore } from '@angular/fire/firestore';
 import { AngularFireStorage } from '@angular/fire/storage';
 import * as firebase from 'firebase';
-import { combineLatest, forkJoin, merge, Observable, of, zip } from 'rxjs';
-import {
-  concatMap,
-  map,
-  mergeMap,
-  switchMap,
-  tap,
-  withLatestFrom,
-} from 'rxjs/operators';
+import { combineLatest, Observable, of } from 'rxjs';
+import { map, switchMap } from 'rxjs/operators';
 import { Event } from '../interfaces/event';
 import { Image, ImageWithUser } from '../interfaces/image';
 import { User } from '../interfaces/user';
@@ -72,16 +65,16 @@ export class ImageService {
       .collection<Event>(`users/${uid}/joinedEvents`)
       .valueChanges()
       .pipe(
-        switchMap((events) => {
+        switchMap((events: Event[]) => {
           if (events.length) {
             return combineLatest(
-              events.map((event) => this.getImages(event.eventId))
+              events.map((event: Event) => this.getImages(event.eventId))
             );
           } else {
             return of(null);
           }
         }),
-        map((imagesArray) => {
+        map((imagesArray: Image[][]) => {
           if (imagesArray?.length) {
             return Array.prototype.concat.apply([], imagesArray);
           }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -85,3 +85,8 @@ button {
 .mat-form-field-appearance-fill .mat-form-field-flex {
   background-color: transparent;
 }
+
+.mat-tab .mat-tab-label {
+  min-width: 0px !important;
+  width: 120px;
+}


### PR DESCRIPTION
- 新着投稿タブ追加
- 参加ルームを横断した新着投稿一覧の取得と表示

上手くいかないと思っていたのは殆どのユーザーが退会してたからでした...。
カードにいいねも表示させようとした時に、likedUidから取っている弊害に気付きました。
別issueで、やはりlikeCountに追加して使いやすくしましょう。