### PR TITLE
新着投稿の取得時のソート修正 + Actionsエラー対応

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,9 +1,110 @@
 {
-  "indexes": [],
+  "indexes": [
+    {
+      "collectionGroup": "images",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        {
+          "fieldPath": "eventId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "images",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        {
+          "fieldPath": "eventId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "images",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        {
+          "fieldPath": "eventId",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "createAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "images",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        {
+          "fieldPath": "eventId",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    }
+  ],
   "fieldOverrides": [
     {
       "collectionGroup": "comments",
       "fieldPath": "eventId",
+      "indexes": [
+        {
+          "order": "ASCENDING",
+          "queryScope": "COLLECTION"
+        },
+        {
+          "order": "DESCENDING",
+          "queryScope": "COLLECTION"
+        },
+        {
+          "arrayConfig": "CONTAINS",
+          "queryScope": "COLLECTION"
+        },
+        {
+          "order": "ASCENDING",
+          "queryScope": "COLLECTION_GROUP"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "comments",
+      "fieldPath": "uid",
+      "indexes": [
+        {
+          "order": "ASCENDING",
+          "queryScope": "COLLECTION"
+        },
+        {
+          "order": "DESCENDING",
+          "queryScope": "COLLECTION"
+        },
+        {
+          "arrayConfig": "CONTAINS",
+          "queryScope": "COLLECTION"
+        },
+        {
+          "order": "ASCENDING",
+          "queryScope": "COLLECTION_GROUP"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "events",
+      "fieldPath": "joinedUserCount",
       "indexes": [
         {
           "order": "ASCENDING",
@@ -70,6 +171,28 @@
     {
       "collectionGroup": "joinedEvents",
       "fieldPath": "eventId",
+      "indexes": [
+        {
+          "order": "ASCENDING",
+          "queryScope": "COLLECTION"
+        },
+        {
+          "order": "DESCENDING",
+          "queryScope": "COLLECTION"
+        },
+        {
+          "arrayConfig": "CONTAINS",
+          "queryScope": "COLLECTION"
+        },
+        {
+          "order": "ASCENDING",
+          "queryScope": "COLLECTION_GROUP"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "joinedEvents",
+      "fieldPath": "uid",
       "indexes": [
         {
           "order": "ASCENDING",

--- a/src/app/home/home/home.component.html
+++ b/src/app/home/home/home.component.html
@@ -21,7 +21,7 @@
     <mat-tab label="新着投稿">
       <div class="mat-tab__card-layout mat-tab__card-layout--posts">
         <app-recent-posts
-          *ngFor="let image of images$ | async as images"
+          *ngFor="let image of images"
           [image]="image"
           [routerLink]="'/event/' + image.eventId"
         ></app-recent-posts>

--- a/src/app/home/home/home.component.ts
+++ b/src/app/home/home/home.component.ts
@@ -2,9 +2,9 @@ import { Component, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute } from '@angular/router';
 import { Observable } from 'rxjs';
-import { map, switchMap } from 'rxjs/operators';
+import { map, switchMap, take } from 'rxjs/operators';
 import { Event } from 'src/app/interfaces/event';
-import { Image } from 'src/app/interfaces/image';
+import { ImageWithUser } from 'src/app/interfaces/image';
 import { User } from 'src/app/interfaces/user';
 import { AuthService } from 'src/app/services/auth.service';
 import { EventService } from 'src/app/services/event.service';
@@ -20,7 +20,7 @@ import { JoinEventDialogComponent } from './join-event-dialog/join-event-dialog.
 export class HomeComponent implements OnInit {
   uid: string;
   user$: Observable<User> = this.authService.user$;
-  images$: Observable<Image[]>;
+  images: ImageWithUser[];
 
   eventId$: Observable<string> = this.route.paramMap.pipe(
     map((param) => {
@@ -59,7 +59,15 @@ export class HomeComponent implements OnInit {
     this.user$.subscribe((user) => {
       this.uid = user.uid;
     });
-    this.images$ = this.imageService.getRecentImagesInJoinedEvents(this.uid);
+    this.imagesInit();
+  }
+
+  async imagesInit(): Promise<void> {
+    this.images = await (
+      await this.imageService.getRecentImagesInJoinedEvents(this.uid)
+    )
+      .pipe(take(1))
+      .toPromise();
   }
 
   openJoinEventDialog(id?: string) {

--- a/src/app/services/image.service.ts
+++ b/src/app/services/image.service.ts
@@ -74,7 +74,7 @@ export class ImageService {
             ref
               .where('eventId', 'in', ids)
               .orderBy('createAt', 'desc')
-              .limit(10)
+              .limit(20)
           )
           .valueChanges()
           .pipe(

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -4,6 +4,8 @@ import { AngularFireFunctions } from '@angular/fire/functions';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
 import { Observable } from 'rxjs';
+import { map, take } from 'rxjs/operators';
+import { Event } from '../interfaces/event';
 import { User } from '../interfaces/user';
 
 @Injectable({
@@ -25,7 +27,14 @@ export class UserService {
       eventId,
       uid,
     });
-    this.db.doc(`users/${uid}/joinedEvents/${eventId}`).set({ eventId });
+    this.db.doc(`users/${uid}/joinedEvents/${eventId}`).set({ eventId, uid });
+  }
+
+  getJoinedEventIds(uid: string): Observable<string[]> {
+    return this.db
+      .collection(`users/${uid}/joinedEvents`)
+      .valueChanges()
+      .pipe(map((evs) => evs.map((e: Event) => e.eventId)));
   }
 
   async updateUser(user: Omit<User, 'createdAt'>) {


### PR DESCRIPTION
- 新着投稿タブに表示させた投稿写真リストをイベントを横断してorderBy
- Actionsエラー対応

イベント毎に別れてcreatedAt順で並んでいたものをイベントを横断してoederByするように変更しました。
ただしfirestoreでは検索クエリが最大10までの制限があるため、参加イベントがそれ以上になりそうになった場合、
クライアントでソートする設計に修正する必要があります。