### PR TITLE
イベント画面 三点リーダーからゴミ箱アイコンのみに変更

### DIFF
--- a/src/app/event/event/image-list/image-card/image-card.component.html
+++ b/src/app/event/event/image-list/image-card/image-card.component.html
@@ -6,21 +6,11 @@
     <ng-container *ngIf="user$ | async as user">
       <button
         class="image-card__menu"
-        mat-icon-button
-        [matMenuTriggerFor]="menu"
-        *ngIf="user?.uid == image.uid"
+        mat-menu-item
+        (click)="openDeleteDialog(image.imageId)"
       >
-        <mat-icon>more_vert</mat-icon>
+        <mat-icon>delete</mat-icon>
       </button>
-
-      <mat-menu #menu="matMenu">
-        <button mat-menu-item (click)="isEditMode()">
-          <mat-icon>edit</mat-icon>編集
-        </button>
-        <button mat-menu-item (click)="openDeleteDialog(image.imageId)">
-          <mat-icon>delete</mat-icon>削除
-        </button>
-      </mat-menu>
     </ng-container>
   </div>
 

--- a/src/app/event/event/image-list/image-card/image-card.component.scss
+++ b/src/app/event/event/image-list/image-card/image-card.component.scss
@@ -27,12 +27,9 @@
   }
   &__menu {
     position: absolute;
-    top: 4px;
+    top: -8px;
     right: 4px;
-    width: 32px;
-    height: 32px;
-    background: rgba(0, 0, 0, 0.38);
-    color: #fff;
+    width: 40px;
     mat-icon {
       height: 32px;
     }


### PR DESCRIPTION
fix #142 

三点リーダーからゴミ箱アイコンのみに変更しました！
ご確認よろしくお願いします。
<img width="405" alt="スクリーンショット 2021-03-27 12 36 24" src="https://user-images.githubusercontent.com/61979156/112708995-0c579780-8ef9-11eb-89a9-1f09845ce7cb.png">
