### PR TITLE
イベント参加時のダイアログ修正

### DIFF
--- a/src/app/shared/join-event-dialog/join-event-dialog.component.html
+++ b/src/app/shared/join-event-dialog/join-event-dialog.component.html
@@ -23,7 +23,6 @@
         mat-button
         class="form__submit"
         type="submit"
-        [mat-dialog-close]="true"
         [disabled]="passwordForm.invalid || passwordForm.pristine"
         [class.disabled]="passwordForm.invalid || passwordForm.pristine"
       >

--- a/src/app/shared/join-event-dialog/join-event-dialog.component.ts
+++ b/src/app/shared/join-event-dialog/join-event-dialog.component.ts
@@ -1,6 +1,6 @@
 import { Component, Inject, OnInit } from '@angular/core';
 import { FormControl, Validators } from '@angular/forms';
-import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
 import { User } from 'src/app/interfaces/user';
@@ -25,6 +25,7 @@ export class JoinEventDialogComponent implements OnInit {
   constructor(
     private eventService: EventService,
     private router: Router,
+    private dialogRef: MatDialogRef<JoinEventDialogComponent>,
     private snackBar: MatSnackBar,
     @Inject(MAT_DIALOG_DATA)
     public data: {
@@ -40,7 +41,9 @@ export class JoinEventDialogComponent implements OnInit {
       this.data.id
     );
     if (this.isPossible) {
+      this.dialogRef.close();
       this.router.navigateByUrl(`event/${this.data.id}`);
+      this.snackBar.open('パスワードに成功しました✨');
     } else {
       this.snackBar.open('パスワードが違います');
     }


### PR DESCRIPTION
fix #155 

イベント参加時のダイアログ修正を行いました！
ご確認よろしくお願い致します。

作業内容
・passwordが間違えていた場合→スナックバー表示、ダイアログ閉じない
・passwordが成功したときにスナップショットを表示、ダイアログ閉じる