### PR TITLE
イベントから退出する際に削除する項目の削除機能追加、修正＆スタイル調整

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -127,5 +127,8 @@
       }
     }
   },
-  "defaultProject": "Instacircle"
+  "defaultProject": "Instacircle",
+  "cli": {
+    "analytics": false
+  }
 }

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -23,6 +23,20 @@
           "order": "ASCENDING"
         },
         {
+          "fieldPath": "uid",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "images",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        {
+          "fieldPath": "eventId",
+          "order": "ASCENDING"
+        },
+        {
           "fieldPath": "createdAt",
           "order": "DESCENDING"
         }

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -69,6 +69,34 @@
           "order": "DESCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "likedUids",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        {
+          "fieldPath": "eventId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "likedUid",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "comments",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        {
+          "fieldPath": "eventId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "ownerId",
+          "order": "ASCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": [

--- a/functions/src/event.function.ts
+++ b/functions/src/event.function.ts
@@ -118,25 +118,33 @@ export const deleteImagesInTheEvent = functions
         .collectionGroup('images')
         .where('uid', '==', uid)
         .where('eventId', '==', eventId);
-      const comments: FirebaseFirestore.Query<FirebaseFirestore.DocumentData> = db
+      const allComments: FirebaseFirestore.Query<FirebaseFirestore.DocumentData> = db
         .collectionGroup('comments')
-        .where('uid', '==', uid)
-        .where('eventId', '==', eventId);
+        .where('eventId', '==', eventId)
+        .where('ownerId', '==', uid);
+      const allMyComments: FirebaseFirestore.Query<FirebaseFirestore.DocumentData> = db
+        .collectionGroup('comments')
+        .where('uid', '==', uid);
       const imageFavorite: FirebaseFirestore.Query<FirebaseFirestore.DocumentData> = db
         .collectionGroup('likedUids')
-        .where('likedUids', '==', uid)
+        .where('likedUid', '==', uid)
+        .where('eventId', '==', eventId);
+      const myFavorite: FirebaseFirestore.Query<FirebaseFirestore.DocumentData> = db
+        .collection(`users/${uid}/likedImages`)
         .where('eventId', '==', eventId);
 
       const deleteAllImagesPostedByMySelf = deleteCollectionByReference(images);
-      const deleteAllCommentsPostedByMySelf = deleteCollectionByReference(
-        comments
-      );
+      const deleteAllComments = deleteCollectionByReference(allComments);
+      const deleteAllMyComments = deleteCollectionByReference(allMyComments);
       const deleteAllFavorite = deleteCollectionByReference(imageFavorite);
+      const deleteAllMyFavorite = deleteCollectionByReference(myFavorite);
 
       await Promise.all([
-        deleteAllCommentsPostedByMySelf,
+        deleteAllComments,
+        deleteAllMyComments,
         deleteAllImagesPostedByMySelf,
         deleteAllFavorite,
+        deleteAllMyFavorite,
       ]);
     }
   });

--- a/functions/src/event.function.ts
+++ b/functions/src/event.function.ts
@@ -122,13 +122,21 @@ export const deleteImagesInTheEvent = functions
         .collectionGroup('comments')
         .where('uid', '==', uid)
         .where('eventId', '==', eventId);
+      const imageFavorite: FirebaseFirestore.Query<FirebaseFirestore.DocumentData> = db
+        .collectionGroup('likedUids')
+        .where('likedUids', '==', uid)
+        .where('eventId', '==', eventId);
+
       const deleteAllImagesPostedByMySelf = deleteCollectionByReference(images);
       const deleteAllCommentsPostedByMySelf = deleteCollectionByReference(
         comments
       );
+      const deleteAllFavorite = deleteCollectionByReference(imageFavorite);
+
       await Promise.all([
         deleteAllCommentsPostedByMySelf,
         deleteAllImagesPostedByMySelf,
+        deleteAllFavorite,
       ]);
     }
   });

--- a/src/app/event/event/event.component.html
+++ b/src/app/event/event/event.component.html
@@ -26,6 +26,7 @@
           <div class="event__share">
             <button
               class="event__share-btn"
+              (click)="copyUrl()"
               [cdkCopyToClipboard]="eventInvitateURL"
             >
               <mat-icon>content_copy</mat-icon>

--- a/src/app/event/event/event.component.html
+++ b/src/app/event/event/event.component.html
@@ -39,7 +39,7 @@
               aria-label="イベント設定"
               [matMenuTriggerFor]="eventMenu"
             >
-              <mat-icon>more_vert</mat-icon>
+              <mat-icon class="event__more">more_vert</mat-icon>
             </button>
             <mat-menu #eventMenu="matMenu">
               <a

--- a/src/app/event/event/event.component.scss
+++ b/src/app/event/event/event.component.scss
@@ -112,6 +112,9 @@
     top: -10px;
     right: 0;
   }
+  &__more {
+    color: #fff;
+  }
   &__blank {
     box-sizing: border-box;
     display: flex;

--- a/src/app/event/event/event.component.ts
+++ b/src/app/event/event/event.component.ts
@@ -64,6 +64,6 @@ export class EventComponent implements OnInit {
   }
 
   copyUrl(): void {
-    this.snackBar.open('招待URLをコピーしました');
+    this.snackBar.open('リンクをコピーしました🥳');
   }
 }

--- a/src/app/event/event/event.component.ts
+++ b/src/app/event/event/event.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { ActivatedRoute } from '@angular/router';
 import { Observable } from 'rxjs';
 import { switchMap, take } from 'rxjs/operators';
@@ -30,7 +31,8 @@ export class EventComponent implements OnInit {
     private dialog: MatDialog,
     private eventServise: EventService,
     public authServise: AuthService,
-    private routeService: RouteParamsService
+    private routeService: RouteParamsService,
+    private snackBar: MatSnackBar
   ) {}
 
   ngOnInit(): void {
@@ -59,5 +61,9 @@ export class EventComponent implements OnInit {
         eventId: this.eventId,
       },
     });
+  }
+
+  copyUrl(): void {
+    this.snackBar.open('招待URLをコピーしました');
   }
 }

--- a/src/app/event/event/event.component.ts
+++ b/src/app/event/event/event.component.ts
@@ -53,8 +53,6 @@ export class EventComponent implements OnInit {
 
   exitEventOpenDialog() {
     this.dialog.open(ExitEventDialogComponent, {
-      width: '800px',
-      height: '400px',
       autoFocus: false,
       restoreFocus: false,
       data: {

--- a/src/app/event/event/image-detail/comment-form/comment-form.component.html
+++ b/src/app/event/event/image-detail/comment-form/comment-form.component.html
@@ -7,7 +7,14 @@
         matTextareaAutosize
         matInput
       ></textarea>
-      <mat-icon (click)="createComment(image)" matSuffix>send</mat-icon>
+      <button
+        (click)="createComment(image)"
+        mat-icon-button
+        matSuffix
+        [disabled]="!commentForm.dirty"
+      >
+        <mat-icon>send</mat-icon>
+      </button>
       <mat-error *ngIf="commentForm.hasError('maxLength')"></mat-error>
     </mat-form-field>
   </div>

--- a/src/app/event/event/image-detail/comment-form/comment-form.component.scss
+++ b/src/app/event/event/image-detail/comment-form/comment-form.component.scss
@@ -1,6 +1,7 @@
 mat-form-field {
   width: 100%;
 }
+
 mat-icon {
   color: rgba(0, 0, 0, 0.6);
 }

--- a/src/app/event/event/image-detail/comment-form/comment-form.component.ts
+++ b/src/app/event/event/image-detail/comment-form/comment-form.component.ts
@@ -22,6 +22,7 @@ export class CommentFormComponent implements OnInit {
         'uid' | 'createdAt' | 'imageId' | 'imageURL' | 'commentId' | 'eventId'
       > = {
         commentBody: this.commentForm.value,
+        ownerId: image.uid,
       };
       this.commentService.createComment(image, comment);
       this.commentForm.reset();

--- a/src/app/event/event/image-detail/comment-header/comment-header.component.html
+++ b/src/app/event/event/image-detail/comment-header/comment-header.component.html
@@ -1,15 +1,39 @@
-<header>
+<header *ngIf="authService.user$ | async as user">
   <button class="back-bottun">
     <mat-icon (click)="back()">keyboard_arrow_left</mat-icon>
   </button>
+
   <div class="provider">
-    <div class="provider__header">
-      Photo by
-      <span class="provider__name">{{ provider.name }}</span>
-    </div>
-    <figure
-      class="provider__avatar"
-      [style.background-image]="'url(' + provider.avatarURL + ')'"
-    ></figure>
+    <ng-container *ngIf="user.uid === provider.uid">
+      <label class="provider__label">Photo of</label>
+      <h2 class="provider__name--myself">myself</h2>
+    </ng-container>
+
+    <ng-container *ngIf="user.uid !== provider.uid"
+      ><label class="provider__label">Photo by</label>
+      <h2 class="provider__name">{{ provider.name }}</h2>
+      <figure
+        class="provider__avatar"
+        [style.background-image]="'url(' + provider.avatarURL + ')'"
+      ></figure>
+    </ng-container>
   </div>
+
+  <button
+    *ngIf="authService.user$ | async as user"
+    mat-mini-fab
+    [matMenuTriggerFor]="userMenu"
+    [style.background-image]="'url(' + user?.avatarURL + ')'"
+    class="user-btn"
+  ></button>
+  <mat-menu #userMenu="matMenu">
+    <a mat-menu-item routerLink="/settings">
+      <mat-icon>settings</mat-icon>
+      <span>設定</span>
+    </a>
+    <button mat-menu-item (click)="authService.logout()">
+      <mat-icon>exit_to_app</mat-icon>
+      <span>ログアウト</span>
+    </button>
+  </mat-menu>
 </header>

--- a/src/app/event/event/image-detail/comment-header/comment-header.component.scss
+++ b/src/app/event/event/image-detail/comment-header/comment-header.component.scss
@@ -1,33 +1,57 @@
+@import 'mixins';
+
 header {
-  position: relative;
   display: flex;
   height: 56px;
-  justify-content: center;
   align-items: center;
   color: #707070;
+  padding: 0 16px;
+  @include pc {
+    padding: 0 24px;
+  }
 }
-.back-bottun {
-  position: absolute;
-  font-size: 32px;
 
-  left: 16px;
+.back-bottun {
   color: #333;
   background-color: inherit;
+  margin-left: -8px;
+  margin-right: 8px;
 }
-.provider {
-  padding-top: 16px;
+
+.header-items {
   display: flex;
   align-items: center;
-  margin-bottom: 16px;
-  color: rgba(250, 119, 109, 0.6);
-  &__header {
-    font-size: 24px;
+
+  button {
     margin-right: 8px;
+  }
+
+  label {
+    margin-top: -4px;
+  }
+}
+
+.provider {
+  display: grid;
+  grid-template-columns: repeat(3, auto);
+  align-items: center;
+  gap: 8px;
+  &__label {
+    color: rgba(250, 119, 109, 0.6);
+    font-size: 24px;
+    margin-top: -2px;
+    line-height: 1.5;
   }
   &__name {
     font-size: 16px;
     font-weight: 300;
     color: #888888;
+    margin: 0 0 -2px 0;
+    &--myself {
+      font-size: 20px;
+      font-weight: 300;
+      margin: 0;
+    }
   }
   &__avatar {
     width: 32px;
@@ -36,4 +60,10 @@ header {
     border-radius: 50%;
     background: center/cover rgba(0, 0, 0, 0.5);
   }
+}
+
+.user-btn {
+  box-shadow: none;
+  background: center / cover no-repeat;
+  margin-left: auto;
 }

--- a/src/app/event/event/image-detail/comment-header/comment-header.component.ts
+++ b/src/app/event/event/image-detail/comment-header/comment-header.component.ts
@@ -3,6 +3,7 @@ import { ImageService } from 'src/app/services/image.service';
 import { ActivatedRoute } from '@angular/router';
 import { UserService } from 'src/app/services/user.service';
 import { User } from 'src/app/interfaces/user';
+import { AuthService } from 'src/app/services/auth.service';
 
 @Component({
   selector: 'app-comment-header',
@@ -12,7 +13,7 @@ import { User } from 'src/app/interfaces/user';
 export class CommentHeaderComponent implements OnInit {
   @Input() provider: User;
 
-  constructor() {}
+  constructor(public authService: AuthService) {}
 
   ngOnInit(): void {}
 

--- a/src/app/event/event/image-detail/comment-list/comment-list.component.html
+++ b/src/app/event/event/image-detail/comment-list/comment-list.component.html
@@ -4,15 +4,15 @@
       class="comment__avatar"
       [style.background-image]="'url(' + comment.user?.avatarURL + ')'"
     ></figure>
-    <div class="comment__body">
-      <p class="comment__body">
-        <span class="comment__name">
-          {{ comment.user?.name }}
-        </span>
-        {{ comment.commentBody }}
-      </p>
+    <div class="comment__items">
+      <span class="comment__user-name">
+        {{ comment.user?.name }}
+      </span>
       <p class="comment__date">
         {{ comment.createdAt.toDate() | date: 'M/d HH:mm' }}
+      </p>
+      <p class="comment__body">
+        {{ comment.commentBody }}
       </p>
     </div>
     <div>

--- a/src/app/event/event/image-detail/comment-list/comment-list.component.scss
+++ b/src/app/event/event/image-detail/comment-list/comment-list.component.scss
@@ -2,10 +2,11 @@ figure {
   margin: 0;
   padding: 0;
 }
+
 .comment {
   padding: 8px 0;
   display: grid;
-  gap: 8px;
+  gap: 12px;
   grid-template-columns: 40px 1fr 40px;
   &__avatar {
     width: 40px;
@@ -16,5 +17,10 @@ figure {
   &__name {
     line-height: 1;
     margin-right: 8px;
+  }
+  &__body {
+    margin: 0;
+    white-space: pre-line;
+    word-break: break-all;
   }
 }

--- a/src/app/event/event/image-detail/image-detail.component.html
+++ b/src/app/event/event/image-detail/image-detail.component.html
@@ -11,28 +11,26 @@
         <img [src]="image.imageURL" [alt]="" />
         <div class="area">
           <!-- いいね -->
-          <div>
-            <ng-container *ngIf="!isLiked">
-              <button mat-icon-button (click)="likeImage(image.imageId)">
-                <mat-icon class="like">favorite_border</mat-icon>
-                <span class="like-count">{{ likedCount }}</span>
-              </button>
-            </ng-container>
-            <ng-container *ngIf="isLiked">
-              <button mat-icon-button (click)="UnLikeImage(image.imageId)">
-                <mat-icon class="like">favorite</mat-icon>
-                <span class="like-count">{{ likedCount }}</span>
-              </button>
-            </ng-container>
-          </div>
+          <button
+            *ngIf="!isLiked"
+            mat-icon-button
+            (click)="likeImage(image.imageId)"
+          >
+            <mat-icon class="like">favorite_border</mat-icon>
+            <span class="like-count">{{ likedCount }}</span>
+          </button>
+          <button
+            *ngIf="isLiked"
+            mat-icon-button
+            (click)="UnLikeImage(image.imageId)"
+          >
+            <mat-icon class="like">favorite</mat-icon>
+            <span class="like-count">{{ likedCount }}</span>
+          </button>
           <!-- 投稿時間表示 -->
-          <div>
-            <ng-container *ngIf="image$">
-              <div class="image-createAt">
-                {{ image.createAt.toDate() | date: 'yyyy年MM月dd ' }}
-              </div>
-            </ng-container>
-          </div>
+          <span *ngIf="image$" class="image-createAt">
+            {{ image.createAt.toDate() | date: 'yyyy年MM月dd ' }}
+          </span>
         </div>
       </div>
 

--- a/src/app/event/event/image-detail/image-detail.component.html
+++ b/src/app/event/event/image-detail/image-detail.component.html
@@ -1,51 +1,49 @@
-<body>
-  <header>
-    <app-comment-header
-      *ngIf="imageProvider$ | async as provider"
-      [provider]="provider"
-    ></app-comment-header>
-  </header>
-  <div class="conatainer">
-    <div class="grid" *ngIf="image$ | async as image">
-      <div class="thumbnail">
-        <img [src]="image.imageURL" [alt]="" />
-        <div class="area">
-          <!-- いいね -->
-          <button
-            *ngIf="!isLiked"
-            mat-icon-button
-            (click)="likeImage(image.imageId)"
-          >
-            <mat-icon class="like">favorite_border</mat-icon>
-            <span class="like-count">{{ likedCount }}</span>
-          </button>
-          <button
-            *ngIf="isLiked"
-            mat-icon-button
-            (click)="UnLikeImage(image.imageId)"
-          >
-            <mat-icon class="like">favorite</mat-icon>
-            <span class="like-count">{{ likedCount }}</span>
-          </button>
-          <!-- 投稿時間表示 -->
-          <span *ngIf="image$" class="image-createAt">
-            {{ image.createAt.toDate() | date: 'yyyy年MM月dd ' }}
-          </span>
-        </div>
+<div class="header-wrap">
+  <app-comment-header
+    *ngIf="imageProvider$ | async as provider"
+    [provider]="provider"
+  ></app-comment-header>
+</div>
+<div class="conatainer">
+  <div class="grid" *ngIf="image$ | async as image">
+    <div class="thumbnail">
+      <img [src]="image.imageURL" [alt]="" />
+      <div class="area">
+        <!-- いいね -->
+        <button
+          *ngIf="!isLiked"
+          mat-icon-button
+          (click)="likeImage(image.imageId)"
+        >
+          <mat-icon class="like">favorite_border</mat-icon>
+          <span class="like-count">{{ likedCount }}</span>
+        </button>
+        <button
+          *ngIf="isLiked"
+          mat-icon-button
+          (click)="UnLikeImage(image.imageId)"
+        >
+          <mat-icon class="like">favorite</mat-icon>
+          <span class="like-count">{{ likedCount }}</span>
+        </button>
+        <!-- 投稿時間表示 -->
+        <span *ngIf="image$" class="image-createAt">
+          {{ image.createAt.toDate() | date: 'yyyy年MM月dd ' }}
+        </span>
       </div>
+    </div>
 
-      <div class="comment">
-        <div class="comment__list">
-          <app-comment-list
-            class="comment__inner"
-            [eventId]="eventId"
-            [imageId]="imageId"
-          ></app-comment-list>
-        </div>
-        <div class="comment__form">
-          <app-comment-form [image]="image"></app-comment-form>
-        </div>
+    <div class="comment">
+      <div class="comment__list">
+        <app-comment-list
+          class="comment__inner"
+          [eventId]="eventId"
+          [imageId]="imageId"
+        ></app-comment-list>
+      </div>
+      <div class="comment__form">
+        <app-comment-form [image]="image"></app-comment-form>
       </div>
     </div>
   </div>
-</body>
+</div>

--- a/src/app/event/event/image-detail/image-detail.component.scss
+++ b/src/app/event/event/image-detail/image-detail.component.scss
@@ -12,13 +12,12 @@ body {
     -webkit-radial-gradient(rgb(255, 249, 249) 30%, rgba(255, 255, 255, 0.9));
 }
 
-header {
+.header-wrap {
   position: fixed;
-  align-items: center;
   top: 0;
   left: 0;
   right: 0;
-  min-height: 56px;
+  max-height: 56px;
   background-color: #fff;
   z-index: 1000;
 }

--- a/src/app/event/event/image-detail/image-detail.component.scss
+++ b/src/app/event/event/image-detail/image-detail.component.scss
@@ -50,7 +50,6 @@ button {
 
 .image-createAt {
   margin-left: 8px;
-  margin-bottom: -3px;
 }
 
 @include sp {
@@ -149,4 +148,13 @@ button {
       overflow-y: scroll;
     }
   }
+}
+
+.like {
+  color: hotpink;
+}
+
+.like-count {
+  margin-top: 2px;
+  margin-left: 4px;
 }

--- a/src/app/event/event/image-detail/image-detail.component.ts
+++ b/src/app/event/event/image-detail/image-detail.component.ts
@@ -33,6 +33,7 @@ export class ImageDetailComponent implements OnInit {
       return this.userService.getUserData(uid);
     })
   );
+  isImageDetailPage = true;
   constructor(
     private imageService: ImageService,
     private route: ActivatedRoute,

--- a/src/app/event/event/image-list/image-card/image-card.component.scss
+++ b/src/app/event/event/image-list/image-card/image-card.component.scss
@@ -44,6 +44,7 @@
   }
   &__like {
     font-size: 16px;
+    color: hotpink;
     @include pc {
       font-size: 18px;
     }

--- a/src/app/event/exit-event-dialog/exit-event-dialog.component.html
+++ b/src/app/event/exit-event-dialog/exit-event-dialog.component.html
@@ -4,7 +4,7 @@
   <p>本当にイベントから退会しますか？</p>
   <section class="example-section">
     <mat-checkbox
-      (change)="isDeleteAllImages = $event.checked"
+      (change)="isDeleteAllImagesAndComments = $event.checked"
       color="primary"
       class="check-box"
       >このイベントで投稿した写真とコメントを全て削除する

--- a/src/app/event/exit-event-dialog/exit-event-dialog.component.html
+++ b/src/app/event/exit-event-dialog/exit-event-dialog.component.html
@@ -1,21 +1,18 @@
-<div class="container">
-  <h1 matDialogTitle>イベント退会</h1>
+<h1 matDialogTitle>イベント退会</h1>
 
-  <mat-dialog-content>
-    <p>本当にイベントから退会しますか？</p>
-    <section class="example-section">
-      <mat-checkbox
-        (change)="isDeleteAllImages = $event.checked"
-        color="primary"
-        class="check-box"
-      >
-        このイベントで投稿した写真とコメントを全て削除する
-      </mat-checkbox>
-    </section>
-  </mat-dialog-content>
+<mat-dialog-content>
+  <p>本当にイベントから退会しますか？</p>
+  <section class="example-section">
+    <mat-checkbox
+      (change)="isDeleteAllImages = $event.checked"
+      color="primary"
+      class="check-box"
+      >このイベントで投稿した写真とコメントを全て削除する
+    </mat-checkbox>
+  </section>
+</mat-dialog-content>
 
-  <mat-dialog-actions align="end">
-    <button mat-button matDialogClose>キャンセル</button>
-    <button (click)="exitEvent()" color="warn" mat-raised-button>退会</button>
-  </mat-dialog-actions>
-</div>
+<mat-dialog-actions align="end">
+  <button mat-button matDialogClose>キャンセル</button>
+  <button (click)="exitEvent()" color="warn" mat-raised-button>退会</button>
+</mat-dialog-actions>

--- a/src/app/event/exit-event-dialog/exit-event-dialog.component.scss
+++ b/src/app/event/exit-event-dialog/exit-event-dialog.component.scss
@@ -1,7 +1,11 @@
 h1 {
-  margin-top: 16px;
+  text-align: center;
 }
 
 mat-dialog-content {
-  padding: 24px;
+  overflow: initial;
+  p {
+    text-align: center;
+    font-weight: 500;
+  }
 }

--- a/src/app/event/exit-event-dialog/exit-event-dialog.component.scss
+++ b/src/app/event/exit-event-dialog/exit-event-dialog.component.scss
@@ -1,9 +1,14 @@
+@import 'mixins';
+
 h1 {
   text-align: center;
 }
 
 mat-dialog-content {
   overflow: initial;
+  @include sp {
+    padding: 0 16px;
+  }
   p {
     text-align: center;
     font-weight: 500;

--- a/src/app/event/exit-event-dialog/exit-event-dialog.component.ts
+++ b/src/app/event/exit-event-dialog/exit-event-dialog.component.ts
@@ -33,8 +33,8 @@ export class ExitEventDialogComponent implements OnInit {
     const uid: string = this.authService.uid;
     const eventId: string = this.data.eventId;
 
-    await this.eventService.exitEvent(eventId, uid);
-    await this.userService.deleteJoinedEventId(uid, eventId);
+    // await this.eventService.exitEvent(eventId, uid);
+    // await this.userService.deleteJoinedEventId(uid, eventId);
 
     if (this.isDeleteAllImagesAndComments) {
       this.eventService.deleteImagesAndCommentsInTheEvent(eventId);
@@ -43,7 +43,7 @@ export class ExitEventDialogComponent implements OnInit {
     this.dialogRef.close();
     this.dialogRef.afterClosed().subscribe(() => {
       this.snackBar.open('イベントから退会しました');
-      this.router.navigateByUrl('/');
+      // this.router.navigateByUrl('/');
     });
   }
 }

--- a/src/app/event/exit-event-dialog/exit-event-dialog.component.ts
+++ b/src/app/event/exit-event-dialog/exit-event-dialog.component.ts
@@ -12,7 +12,7 @@ import { UserService } from 'src/app/services/user.service';
   styleUrls: ['./exit-event-dialog.component.scss'],
 })
 export class ExitEventDialogComponent implements OnInit {
-  isDeleteAllImages: false;
+  isDeleteAllImagesAndComments: false;
 
   constructor(
     @Inject(MAT_DIALOG_DATA)
@@ -36,10 +36,8 @@ export class ExitEventDialogComponent implements OnInit {
     await this.eventService.exitEvent(eventId, uid);
     await this.userService.deleteJoinedEventId(uid, eventId);
 
-    if (this.isDeleteAllImages) {
-      console.log('image delete');
-
-      this.eventService.deleteImagesAndCommentsInTheEvent(eventId, uid);
+    if (this.isDeleteAllImagesAndComments) {
+      this.eventService.deleteImagesAndCommentsInTheEvent(eventId);
     }
 
     this.dialogRef.close();

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -1,7 +1,7 @@
 <header class="header">
   <h1 class="header__logo">
     <a href="" class="header__logo-link"
-      ><img src="./assets/images/favicon.svg" alt="" />Instacircle</a
+      ><img src="./assets/images/favicon.svg" alt="" />Instacircle</a
     >
   </h1>
   <div class="actions">
@@ -10,7 +10,7 @@
       <span>イベントに参加する</span>
     </button>
     <a mat-button routerLink="/create-event">
-      <mat-icon inline="true">create</mat-icon>
+      <mat-icon inline="true">assignment_ind</mat-icon>
       <span>イベントを作る</span>
     </a>
     <ng-container *ngIf="authService.user$ | async as user; else default">

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -35,7 +35,7 @@
           <mat-icon>settings</mat-icon>
           <span>設定</span>
         </a>
-        <button mat-menu-item (click)="logout()">
+        <button mat-menu-item (click)="authService.logout()">
           <mat-icon>exit_to_app</mat-icon>
           <span>ログアウト</span>
         </button>

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -4,40 +4,44 @@
       ><img src="./assets/images/favicon.svg" alt="" />Instacircle</a
     >
   </h1>
-  <ng-container *ngIf="authService.user$ | async as user; else default">
-    <ng-container *ngIf="event$ | async as event">
+  <div class="actions">
+    <button mat-ripple mat-button (click)="openJoinEventDialog()">
+      <mat-icon inline="true">group</mat-icon>
+      <span>イベントに参加する</span>
+    </button>
+    <a mat-button routerLink="/create-event">
+      <mat-icon inline="true">create</mat-icon>
+      <span>イベントを作る</span>
+    </a>
+    <ng-container *ngIf="authService.user$ | async as user; else default">
+      <ng-container *ngIf="event$ | async as event">
+        <button
+          class="header__add-btn"
+          [routerLink]="'/event/' + event.eventId + '/post-images'"
+        >
+          <mat-icon inline="true">add</mat-icon>
+          <span>画像を投稿する</span>
+        </button>
+      </ng-container>
+
       <button
-        class="header__add-btn"
-        [routerLink]="'/event/' + event.eventId + '/post-images'"
-      >
-        <mat-icon>add</mat-icon> 画像を投稿する
-      </button>
+        mat-mini-fab
+        [matMenuTriggerFor]="userMenu"
+        [style.background-image]="'url(' + user?.avatarURL + ')'"
+        class="header__icon"
+      ></button>
+      <mat-menu #userMenu="matMenu" class="header__menu">
+        <a mat-menu-item routerLink="/settings">
+          <mat-icon>settings</mat-icon>
+          <span>設定</span>
+        </a>
+        <button mat-menu-item (click)="logout()">
+          <mat-icon>exit_to_app</mat-icon>
+          <span>ログアウト</span>
+        </button>
+      </mat-menu>
     </ng-container>
-    <button
-      mat-mini-fab
-      [matMenuTriggerFor]="userMenu"
-      [style.background-image]="'url(' + user?.avatarURL + ')'"
-      class="header__icon"
-    ></button>
-    <mat-menu #userMenu="matMenu" class="header__menu">
-      <a mat-menu-item routerLink="/">
-        <mat-icon>create</mat-icon>
-        <span>イベントを作る</span>
-      </a>
-      <a mat-menu-item (click)="openJoinEventDialog()">
-        <mat-icon>group</mat-icon>
-        <span>イベントに参加する</span>
-      </a>
-      <a mat-menu-item routerLink="/settings">
-        <mat-icon>settings</mat-icon>
-        <span>設定</span>
-      </a>
-      <button mat-menu-item (click)="logout()">
-        <mat-icon>exit_to_app</mat-icon>
-        <span>ログアウト</span>
-      </button>
-    </mat-menu>
-  </ng-container>
+  </div>
   <ng-template #default>
     <button
       class="header__login"

--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -42,7 +42,6 @@
       color: #fff;
       align-items: center;
       outline: none;
-      margin-right: 16px;
       display: flex;
       font-weight: 700;
       font-family: $font-default;
@@ -53,17 +52,18 @@
       width: auto;
       border: 1px solid $color-accent;
       background-color: #fff;
-      color: $color-accent;
       border-radius: 35px;
       font-size: 14px;
+      span,
+      mat-icon {
+        color: $color-accent;
+      }
       &:hover {
         background-color: $color-accent;
         color: #fff;
       }
     }
     mat-icon {
-      width: 16px;
-      height: 16px;
       font-size: 16px;
       margin-right: 4px;
     }
@@ -83,5 +83,23 @@
     &:hover {
       background-color: $color-main;
     }
+  }
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  button,
+  a {
+    font-weight: 600;
+    color: $color-font;
+    margin-left: 4px;
+    mat-icon {
+      font-size: 18px;
+      margin-right: 4px;
+    }
+  }
+  button:last-of-type {
+    margin-left: 16px;
   }
 }

--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -60,7 +60,10 @@
       }
       &:hover {
         background-color: $color-accent;
-        color: #fff;
+        span,
+        mat-icon {
+          color: #fff;
+        }
       }
     }
     mat-icon {
@@ -91,6 +94,9 @@
   align-items: center;
   button,
   a {
+    @include sp {
+      display: none;
+    }
     font-weight: 600;
     color: $color-font;
     margin-left: 4px;
@@ -100,6 +106,7 @@
     }
   }
   button:last-of-type {
+    display: block;
     margin-left: 16px;
   }
 }

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -60,10 +60,4 @@ export class HeaderComponent implements OnInit, OnDestroy {
       data: { id },
     });
   }
-
-  logout(): void {
-    this.authService
-      .logout()
-      .then(() => this.snackBar.open('ログアウトしました'));
-  }
 }

--- a/src/app/home/home/create-event/create-event.component.scss
+++ b/src/app/home/home/create-event/create-event.component.scss
@@ -1,4 +1,5 @@
 @import 'variables';
+@import 'mixins';
 
 * {
   box-sizing: border-box;
@@ -9,6 +10,9 @@
   height: 100%;
   background: url(/assets/images/bg-img.png) no-repeat center/cover;
   padding: 80px 0;
+  @include sp {
+    padding: 24px 0;
+  }
 }
 
 .heading {
@@ -16,9 +20,13 @@
   width: 80%;
   padding: 16px 24px;
   margin: 0 auto;
+  @include sp {
+    padding: 0;
+  }
   &__text {
     color: #fff;
     font-weight: 600;
+    margin-bottom: 24px;
   }
 }
 
@@ -26,29 +34,20 @@
   text-align: center;
   padding: 24px;
   width: 100%;
-  &__title {
-    width: 100%;
-    padding: 8px 16px;
-    background: #eee;
-    border-radius: 6px;
-    opacity: 0.6;
-    margin: 0 auto 32px;
+  @include sp {
+    padding: 0;
   }
-  &__descliption {
+  mat-form-field {
     width: 100%;
     padding: 8px 16px;
     background: #eee;
     border-radius: 6px;
     opacity: 0.6;
     margin: 0 auto 32px;
-  }
-  &__password {
-    width: 100%;
-    padding: 8px 16px;
-    background: #eee;
-    border-radius: 6px;
-    opacity: 0.6;
-    margin: 0 auto 32px;
+    @include sp {
+      padding: 4px 8px;
+      margin: 0 auto 30px;
+    }
   }
   &__submit {
     width: 100%;
@@ -58,7 +57,7 @@
     color: #fff;
     cursor: pointer;
     &[disabled] {
-      background: rgba($color-bg-gray, 0.16);
+      background: rgba($color-bg-gray, 0.6);
       cursor: not-allowed;
     }
   }

--- a/src/app/interfaces/comment.ts
+++ b/src/app/interfaces/comment.ts
@@ -9,6 +9,7 @@ export interface Comment {
   imageId: string;
   commentId: string;
   eventId: string;
+  ownerId: string;
 }
 
 export interface CommentWithUser extends Comment {

--- a/src/app/services/comment.service.ts
+++ b/src/app/services/comment.service.ts
@@ -106,15 +106,4 @@ export class CommentService {
         this.snackBar.open('削除しました');
       });
   }
-
-  async getMyCommentIds(uid: string): Promise<string[]> {
-    const comments = await this.db
-      .collectionGroup<Comment>('comments', (ref) =>
-        ref.where('uid', '==', uid)
-      )
-      .valueChanges()
-      .pipe(take(1))
-      .toPromise();
-    return comments.map((comment) => comment.commentId);
-  }
 }

--- a/src/app/services/event.service.ts
+++ b/src/app/services/event.service.ts
@@ -142,24 +142,9 @@ export class EventService {
       );
   }
 
-  async getMyPostImageIds(eventId: string, uid: string): Promise<string[]> {
-    const docs = await this.db
-      .collection(`events/${eventId}/images`, (ref) =>
-        ref.where('uid', '==', uid)
-      )
-      .valueChanges()
-      .pipe(take(1))
-      .toPromise();
-    return docs.map((doc: Image) => doc.imageId);
-  }
-
-  async deleteImagesAndCommentsInTheEvent(eventId: string, uid: string) {
-    const imageIds: string[] = await this.getMyPostImageIds(eventId, uid);
-    const commentIds: string[] = await this.commentService.getMyCommentIds(uid);
+  async deleteImagesAndCommentsInTheEvent(eventId: string) {
     const data = {
       eventId,
-      imageIds,
-      commentIds,
     };
     const callable = this.fns.httpsCallable('deleteImagesInTheEvent');
     return callable(data).toPromise();

--- a/src/app/services/liked.service.ts
+++ b/src/app/services/liked.service.ts
@@ -22,7 +22,9 @@ export class LikedService {
         .doc(`events/${eventId}/images/${imageId}/likedUids/${likedUid}`)
         .set({ likedUid, eventId }),
       // 自分がいいねをした画像をDBの自分のユーザーIDに保持する
-      this.db.doc(`users/${likedUid}/likedImages/${imageId}`).set({ imageId }),
+      this.db
+        .doc(`users/${likedUid}/likedImages/${imageId}`)
+        .set({ imageId, eventId }),
     ]);
   }
 
@@ -39,8 +41,8 @@ export class LikedService {
   // 記事にいいねしているかチェックする
   isLiked(
     eventId: string,
-    imageId: String,
-    likedUid: String
+    imageId: string,
+    likedUid: string
   ): Observable<boolean> {
     return this.db
       .doc(`events/${eventId}/images/${imageId}/likedUids/${likedUid}`)
@@ -51,7 +53,7 @@ export class LikedService {
   // 記事にいいねしている人一覧で取得する
   getLikedCount(
     eventId: string,
-    imageId: String
+    imageId: string
   ): Observable<LikedImageUser[]> {
     return this.db
       .collection<LikedImageUser>(

--- a/src/app/shared/bottom-actions/bottom-actions.component.html
+++ b/src/app/shared/bottom-actions/bottom-actions.component.html
@@ -6,7 +6,6 @@
 >
   <button
     mat-ripple
-    mat-button
     class="bottom-actions__join-event"
     (click)="openJoinEventDialog()"
   >

--- a/src/app/shared/bottom-actions/bottom-actions.component.scss
+++ b/src/app/shared/bottom-actions/bottom-actions.component.scss
@@ -5,6 +5,7 @@
 .bottom-actions {
   display: none;
   transition: background-color 0.4s, color 0.4s;
+  padding: 4px 0;
   @include sp {
     position: fixed;
     z-index: 10;

--- a/src/app/shell/shell.component.html
+++ b/src/app/shell/shell.component.html
@@ -1,3 +1,3 @@
-<app-header></app-header>
-<router-outlet></router-outlet>
+<app-header *ngIf="!isImageDetailPage"></app-header>
+<router-outlet (activate)="checkInner($event)"></router-outlet>
 <app-footer></app-footer>

--- a/src/app/shell/shell.component.ts
+++ b/src/app/shell/shell.component.ts
@@ -6,7 +6,12 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./shell.component.scss'],
 })
 export class ShellComponent implements OnInit {
+  isImageDetailPage: boolean;
   constructor() {}
 
   ngOnInit(): void {}
+
+  checkInner(event: any) {
+    this.isImageDetailPage = event.isImageDetailPage;
+  }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -114,3 +114,11 @@ app-exit-event-dialog {
     }
   }
 }
+
+mat-icon {
+  color: $color-font;
+}
+
+.spacer {
+  flex: 1;
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -103,3 +103,14 @@ button {
     }
   }
 }
+
+app-exit-event-dialog {
+  .mat-checkbox-inner-container {
+    margin: 4px 8px auto auto;
+  }
+  mat-checkbox {
+    span {
+      white-space: pre-wrap;
+    }
+  }
+}


### PR DESCRIPTION
イベントから抜けるタイミングで行われる削除機能の追加、修正と一部スタイルの調整を行いましたので、ご確認よろしくお願い致します。

超元気玉になってしまって非常に申し訳ないです🙏

## 削除機能の項目
- [x] eventの中にあるimagesサブコレクションから自分の投稿した画像全て
- [x] 上記のimageに投稿されたcomments全て
- [x] 同上、いいねの全て
- [x] 他者が投稿した画像に対して自身が投稿したコメント全て
- [x] 同上、いいね全て
- [x] usersコレクション内の自分のドキュメントに存在するサブコレクションlikedUidsで、抜けたイベント内で行ったいいねのID全て

## スタイル調整内容
- PC画面で、ヘッダーにイベント作成、参加ボタンを表示（修正前はuserアイコンのメニューにありました）
- 画像詳細画面のヘッダー修正（ヘッダーが3重構造になっていたので、修正しました）
- 同上ヘッダーで自分の投稿の際は、表示を変更
- 同上ヘッダーで、右端にuserアイコンボタン表示（一つ前の画面に戻らないと設定、ログアウトにいけないのは不便なので）
- いいねボタンの色変更
- mat-iconのcolorをグローバルで統一（variablesにfont-colorが変数化されていたので、それを使用。グローバル管理の理由は、ところどころ色が薄かったり、素の状態（真っ黒）だったりで統一感が無かった為。色を変更したい場合は、使用するコンポーネントで、都度colorの指定をして対応出来ます。）
- 投稿したコメントのスタイル調整（改行するように変更したりなど）
- イベント作成ページの余白をSP画面において調整
- PCサイズで招待リンクコピーをしても反応がなかったので、ボトムツールバーを同じようにスナックバー表示

## イメージ
### イベントから抜ける際の削除機能挙動確認
https://www.loom.com/share/c850b025afc3443fad97d6de2ca3b7ad

### スタイル調整を行った箇所確認
https://www.loom.com/share/20f14010ae844763bad2397bf58e217d